### PR TITLE
base64_decode: always cast to unsigned char when using the input characters as indexes in LUTs

### DIFF
--- a/src/base64.c
+++ b/src/base64.c
@@ -237,7 +237,7 @@ int l8w8jwt_base64_decode(const int url, const char* data, const size_t data_len
 
     for (i = 0; i < in_length; i++)
     {
-        if (dtable[data[i]] != 0x80)
+        if (dtable[(unsigned char)data[i]] != 0x80)
             count++;
     }
 
@@ -263,7 +263,7 @@ int l8w8jwt_base64_decode(const int url, const char* data, const size_t data_len
 
     for (i = 0; i < in_length + r; i++)
     {
-        const int c = i < in_length ? data[i] : '=';
+        const unsigned char c = i < in_length ? data[i] : '=';
 
         tmp = dtable[c];
 


### PR DESCRIPTION
`char`'s signedness is implementation-defined, with most implementations defaulting to signed, so characters above 127 are actually treated as negative.

For this reason, before this fix if invalid base64 data containing >127 characters was passed to `l8w8jwt_base64_decode`, it indexed lookup tables with negative values, reading garbage values from the stack (and potentially crashing if it bumped on a guard page or an unallocated stack portion).

Notice that the problem is not present in the original implementation (http://web.mit.edu/freebsd/head/contrib/wpa/src/utils/base64.c), as it wisely used `unsigned char *` for both input and output.