### PR TITLE
Remove unused types from decoding API

### DIFF
--- a/src/decode.c
+++ b/src/decode.c
@@ -32,8 +32,6 @@ extern "C" {
 #include <mbedtls/pk.h>
 #include <mbedtls/md.h>
 #include <mbedtls/platform_util.h>
-#include <mbedtls/entropy.h>
-#include <mbedtls/ctr_drbg.h>
 #include <mbedtls/pk.h>
 #include <mbedtls/x509_crt.h>
 
@@ -354,12 +352,6 @@ int l8w8jwt_decode(struct l8w8jwt_decoding_params* params, enum l8w8jwt_validati
 
     mbedtls_x509_crt crt;
     mbedtls_x509_crt_init(&crt);
-
-    mbedtls_entropy_context entropy;
-    mbedtls_entropy_init(&entropy);
-
-    mbedtls_ctr_drbg_context ctr_drbg;
-    mbedtls_ctr_drbg_init(&ctr_drbg);
 
 #if L8W8JWT_SMALL_STACK
     unsigned char* key = calloc(sizeof(unsigned char), L8W8JWT_MAX_KEY_SIZE);
@@ -746,9 +738,6 @@ exit:
 #if L8W8JWT_SMALL_STACK
     l8w8jwt_free(key);
 #endif
-
-    mbedtls_ctr_drbg_free(&ctr_drbg);
-    mbedtls_entropy_free(&entropy);
 
     if (is_cert)
     {


### PR DESCRIPTION
Types `mbedtls_entropy_context`, `mbedtls_ctr_drbg_context` are not used in decode.c and are only inited and freed.

Removing the unused types from decode API saves some stack space and helps in case of systems with small stack size which only want to decode on the device for verification purposes and encoding is handled outside of the system.