### PR TITLE
Fix object/array claims encoding and issue #43

### DIFF
--- a/src/claim.c
+++ b/src/claim.c
@@ -50,21 +50,53 @@ void l8w8jwt_free_claims(struct l8w8jwt_claim* claims, const size_t claims_count
 
 static inline void l8w8jwt_escape_claim_string(struct chillbuff* stringbuilder, const char* string, const size_t string_length)
 {
+    static const char* escape_table[] = {
+        "\\u0000", "\\u0001", "\\u0002", "\\u0003", "\\u0004", "\\u0005", "\\u0006", "\\u0007",
+        "\\b", "\\t", "\\n", "\\u000b", "\\f", "\\r", "\\u000e", "\\u000f",
+        "\\u0010", "\\u0011", "\\u0012", "\\u0013", "\\u0014", "\\u0015", "\\u0016", "\\u0017",
+        "\\u0018", "\\u0019", "\\u001a", "\\u001b", "\\u001c", "\\u001d", "\\u001e", "\\u001f",
+        NULL, NULL, "\\\"", NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, "\\/",
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, "\\\\", NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, "\\u007f",
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL,
+        NULL, NULL, NULL, NULL, NULL, NULL, NULL, NULL
+    };
+
     for (size_t i = 0; i < string_length; ++i)
     {
         const char c = string[i];
+        const char* e = escape_table[c];
 
-        switch (c)
+        if (e)
         {
-            case '\\':
-                chillbuff_push_back(stringbuilder, "\\\\", 2);
-                break;
-            case '\"':
-                chillbuff_push_back(stringbuilder, "\\\"", 2);
-                break;
-            default:
-                chillbuff_push_back(stringbuilder, &c, 1);
-                break;
+            chillbuff_push_back(stringbuilder, e, strlen(e));
+        }
+        else
+        {
+            chillbuff_push_back(stringbuilder, &c, 1);
         }
     }
 }

--- a/src/claim.c
+++ b/src/claim.c
@@ -111,15 +111,20 @@ int l8w8jwt_write_claims(struct chillbuff* stringbuilder, struct l8w8jwt_claim* 
         chillbuff_push_back(stringbuilder, "\":", 2);
 
         if (claim->type == L8W8JWT_CLAIM_TYPE_STRING)
+        {
             chillbuff_push_back(stringbuilder, "\"", 1);
 
-        chillbuff_clear(&escape_buffer);
-        l8w8jwt_escape_claim_string(&escape_buffer, claim->value, value_length);
+            chillbuff_clear(&escape_buffer);
+            l8w8jwt_escape_claim_string(&escape_buffer, claim->value, value_length);
 
-        chillbuff_push_back(stringbuilder, escape_buffer.array,escape_buffer.length);
+            chillbuff_push_back(stringbuilder, escape_buffer.array, escape_buffer.length);
 
-        if (claim->type == L8W8JWT_CLAIM_TYPE_STRING)
             chillbuff_push_back(stringbuilder, "\"", 1);
+        }
+        else
+        {
+            chillbuff_push_back(stringbuilder, claim->value, value_length);
+        }
 
         first = 0;
     }


### PR DESCRIPTION
Both issues are caused by escape/unescape, and they've both been fixed in this PR. :)

We can now create and encode object/array claims by writing raw JSON to the value of the claim, and correctly decode object/array claims whose keys or values contain escape characters.

The decoded object/array claims look like as follows:

```C
struct l8w8jwt_claim claims[] =
{
    {
        .key = "nested_obj",
        .key_length = 10,
        .value = "{\"foo\":\"bar\"}",
        .value_length = strlen("{\"foo\":\"bar\"}"),
        .type = L8W8JWT_CLAIM_TYPE_OBJECT
    },
    {
        .key = "nested_arr",
        .key_length = 10,
        .value = "[\"foo\",\"bar\"]",
        .value_length = strlen("[\"foo\",\"bar\"]"),
        .type = L8W8JWT_CLAIM_TYPE_ARRAY
    }
};
```

They can also be used to create JWT.

Link to #43.