### PR TITLE
Added constness on param struct for better compliance

### DIFF
--- a/include/l8w8jwt/claim.h
+++ b/include/l8w8jwt/claim.h
@@ -127,7 +127,7 @@ L8W8JWT_API void l8w8jwt_free_claims(struct l8w8jwt_claim* claims, size_t claims
  * @param claims_count The claims array size.
  * @return Return code as specified inside retcodes.h
  */
-L8W8JWT_API int l8w8jwt_write_claims(struct chillbuff* stringbuilder, struct l8w8jwt_claim* claims, size_t claims_count);
+L8W8JWT_API int l8w8jwt_write_claims(struct chillbuff* stringbuilder, const struct l8w8jwt_claim* claims, size_t claims_count);
 
 /**
  * Gets a claim by key from a l8w8jwt_claim array.
@@ -137,7 +137,7 @@ L8W8JWT_API int l8w8jwt_write_claims(struct chillbuff* stringbuilder, struct l8w
  * @param key_length The claim key's string length.
  * @return The found claim; <code>NULL</code> if no such claim was found in the array.
  */
-L8W8JWT_API struct l8w8jwt_claim* l8w8jwt_get_claim(struct l8w8jwt_claim* claims, size_t claims_count, const char* key, size_t key_length);
+L8W8JWT_API const struct l8w8jwt_claim* l8w8jwt_get_claim(const struct l8w8jwt_claim* claims, size_t claims_count, const char* key, size_t key_length);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/l8w8jwt/decode.h
+++ b/include/l8w8jwt/decode.h
@@ -102,7 +102,7 @@ struct l8w8jwt_decoding_params
     /**
      * The token to decode and validate.
      */
-    char* jwt;
+    const char* jwt;
 
     /**
      * The jwt string length.
@@ -122,7 +122,7 @@ struct l8w8jwt_decoding_params
      * The JWT will only pass verification if its <code>iss</code> claim matches this string.
      * @see https://tools.ietf.org/html/rfc7519#section-4.1.1
      */
-    char* validate_iss;
+    const char* validate_iss;
 
     /**
      * validate_iss string length.
@@ -135,7 +135,7 @@ struct l8w8jwt_decoding_params
      * The JWT will only pass verification if its <code>sub</code> matches this string.
      * @see https://tools.ietf.org/html/rfc7519#section-4.1.2
      */
-    char* validate_sub;
+    const char* validate_sub;
 
     /**
      * validate_sub string length.
@@ -148,7 +148,7 @@ struct l8w8jwt_decoding_params
      * The JWT will only pass verification if its <code>aud</code> matches this string.
      * @see https://tools.ietf.org/html/rfc7519#section-4.1.3
      */
-    char* validate_aud;
+    const char* validate_aud;
 
     /**
      * validate_aud string length.
@@ -161,7 +161,7 @@ struct l8w8jwt_decoding_params
      * The JWT will only pass verification if its <code>jti</code> matches this string.
      * @see https://tools.ietf.org/html/rfc7519#section-4.1.7
      */
-    char* validate_jti;
+    const char* validate_jti;
 
     /**
      * validate_jti claim length.
@@ -209,7 +209,7 @@ struct l8w8jwt_decoding_params
      * The key to use for verifying the token's signature
      * (e.g. if you chose HS256 as algorithm, this will be the HMAC secret; for RS512 this will be the PEM-formatted public RSA key string, etc...).
      */
-    unsigned char* verification_key;
+    const unsigned char* verification_key;
 
     /**
      * Length of the {@link #verification_key}
@@ -220,7 +220,7 @@ struct l8w8jwt_decoding_params
      * [OPTIONAL] The typ claim (what type is the token?). <p>
      * Set to <code>NULL</code> if you don't want to validate the "typ" claim. <p>
      */
-    char* validate_typ;
+    const char* validate_typ;
 
     /**
      * validate_typ string length.
@@ -239,7 +239,7 @@ L8W8JWT_API void l8w8jwt_decoding_params_init(struct l8w8jwt_decoding_params* pa
  * @param params The l8w8jwt_decoding_params to validate.
  * @return Return code as defined in retcodes.h
  */
-L8W8JWT_API int l8w8jwt_validate_decoding_params(struct l8w8jwt_decoding_params* params);
+L8W8JWT_API int l8w8jwt_validate_decoding_params(const struct l8w8jwt_decoding_params* params);
 
 /**
  * Decode (and validate) a JWT using specific parameters. <p>
@@ -268,7 +268,7 @@ L8W8JWT_API int l8w8jwt_validate_decoding_params(struct l8w8jwt_decoding_params*
  *
  * @return Return code as defined in retcodes.h (this is NOT the validation result that's written into the out_validation_result argument; the returned int describes whether the actual parsing/decoding part failed).
  */
-L8W8JWT_API int l8w8jwt_decode(struct l8w8jwt_decoding_params* params, enum l8w8jwt_validation_result* out_validation_result, struct l8w8jwt_claim** out_claims, size_t* out_claims_length);
+L8W8JWT_API int l8w8jwt_decode(const struct l8w8jwt_decoding_params* params, enum l8w8jwt_validation_result* out_validation_result, struct l8w8jwt_claim** out_claims, size_t* out_claims_length);
 
 /**
  * Decode (and validate) a JWT using specific parameters,
@@ -304,7 +304,7 @@ L8W8JWT_API int l8w8jwt_decode(struct l8w8jwt_decoding_params* params, enum l8w8
  *
  * @return Return code as defined in retcodes.h (this is NOT the validation result that's written into the {@link out_validation_result} argument; the returned int describes whether the actual parsing/decoding part failed).
  */
-L8W8JWT_API int l8w8jwt_decode_raw(struct l8w8jwt_decoding_params* params, enum l8w8jwt_validation_result* out_validation_result, char** out_header, size_t* out_header_length, char** out_payload, size_t* out_payload_length, uint8_t** out_signature, size_t* out_signature_length);
+L8W8JWT_API int l8w8jwt_decode_raw(const struct l8w8jwt_decoding_params* params, enum l8w8jwt_validation_result* out_validation_result, char** out_header, size_t* out_header_length, char** out_payload, size_t* out_payload_length, uint8_t** out_signature, size_t* out_signature_length);
 
 /**
  * Decodes a JWT without validating anything: neither claims nor signature. Just raw decoding, no validation!
@@ -325,7 +325,7 @@ L8W8JWT_API int l8w8jwt_decode_raw(struct l8w8jwt_decoding_params* params, enum 
  *
  * @return Return code as defined in retcodes.h
  */
-L8W8JWT_API int l8w8jwt_decode_raw_no_validation(struct l8w8jwt_decoding_params* params, char** out_header, size_t* out_header_length, char** out_payload, size_t* out_payload_length, uint8_t** out_signature, size_t* out_signature_length);
+L8W8JWT_API int l8w8jwt_decode_raw_no_validation(const struct l8w8jwt_decoding_params* params, char** out_header, size_t* out_header_length, char** out_payload, size_t* out_payload_length, uint8_t** out_signature, size_t* out_signature_length);
 
 #ifdef __cplusplus
 } // extern "C"

--- a/include/l8w8jwt/encode.h
+++ b/include/l8w8jwt/encode.h
@@ -53,7 +53,7 @@ L8W8JWT_API struct l8w8jwt_encoding_params
      * [OPTIONAL] The issuer claim (who issued the JWT?). Can be omitted by setting this to <code>NULL</code>.
      * @see https://tools.ietf.org/html/rfc7519#section-4.1.1
      */
-    char* iss;
+    const char* iss;
 
     /**
      * iss claim string length.
@@ -64,7 +64,7 @@ L8W8JWT_API struct l8w8jwt_encoding_params
      * [OPTIONAL] The subject claim (who is the JWT about?). Set to <code>NULL</code> if you don't want it in your token.
      * @see https://tools.ietf.org/html/rfc7519#section-4.1.2
      */
-    char* sub;
+    const char* sub;
 
     /**
      * sub claim string length.
@@ -76,7 +76,7 @@ L8W8JWT_API struct l8w8jwt_encoding_params
      * Set this to <code>NULL</code> if you don't wish to add this claim to the token.
      * @see https://tools.ietf.org/html/rfc7519#section-4.1.3
      */
-    char* aud;
+    const char* aud;
 
     /**
      * aud claim string length.
@@ -87,7 +87,7 @@ L8W8JWT_API struct l8w8jwt_encoding_params
      * [OPTIONAL] The JWT ID. Provides a unique identifier for the token. Can be omitted by setting this to <code>NULL</code>.
      * @see https://tools.ietf.org/html/rfc7519#section-4.1.7
      */
-    char* jti;
+    const char* jti;
 
     /**
      * jti claim string length.
@@ -146,7 +146,7 @@ L8W8JWT_API struct l8w8jwt_encoding_params
      * The secret key to use for signing the token
      * (e.g. if you chose HS256 as algorithm, this will be the HMAC secret; for RS512 this will be the private PEM-formatted RSA key string, and so on...).
      */
-    unsigned char* secret_key;
+    const unsigned char* secret_key;
 
     /**
      * Length of the secret_key
@@ -158,7 +158,7 @@ L8W8JWT_API struct l8w8jwt_encoding_params
      * You can only omit this when using JWT algorithms "HS256", "HS384" or "HS512" (it's ignored in that case actually). <p>
      * Every other algorithm requires you to at least set this to <code>NULL</code> if the {@link #secret_key} isn't password-protected.
      */
-    unsigned char* secret_key_pw;
+    const unsigned char* secret_key_pw;
 
     /**
      * The secret key's password length (if there is any). If there's none, set this to zero!
@@ -188,7 +188,7 @@ L8W8JWT_API void l8w8jwt_encoding_params_init(struct l8w8jwt_encoding_params* pa
  * @param params The l8w8jwt_encoding_params to validate.
  * @return Return code as defined in retcodes.h
  */
-L8W8JWT_API int l8w8jwt_validate_encoding_params(struct l8w8jwt_encoding_params* params);
+L8W8JWT_API int l8w8jwt_validate_encoding_params(const struct l8w8jwt_encoding_params* params);
 
 /**
  * Creates, signs and encodes a Json-Web-Token. <p>

--- a/src/claim.c
+++ b/src/claim.c
@@ -109,7 +109,7 @@ static inline void l8w8jwt_escape_claim_string(struct chillbuff* stringbuilder, 
     }
 }
 
-int l8w8jwt_write_claims(struct chillbuff* stringbuilder, struct l8w8jwt_claim* claims, const size_t claims_count)
+int l8w8jwt_write_claims(struct chillbuff* stringbuilder, const struct l8w8jwt_claim* claims, const size_t claims_count)
 {
     if (stringbuilder == NULL || claims == NULL)
     {
@@ -128,7 +128,7 @@ int l8w8jwt_write_claims(struct chillbuff* stringbuilder, struct l8w8jwt_claim* 
     }
 
     int first = 1;
-    for (struct l8w8jwt_claim* claim = claims; claim < claims + claims_count; ++claim)
+    for (const struct l8w8jwt_claim* claim = claims; claim < claims + claims_count; ++claim)
     {
         if (claim->key == NULL)
         {
@@ -173,12 +173,12 @@ int l8w8jwt_write_claims(struct chillbuff* stringbuilder, struct l8w8jwt_claim* 
     return L8W8JWT_SUCCESS;
 }
 
-struct l8w8jwt_claim* l8w8jwt_get_claim(struct l8w8jwt_claim* claims, const size_t claims_count, const char* key, const size_t key_length)
+const struct l8w8jwt_claim* l8w8jwt_get_claim(const struct l8w8jwt_claim* claims, const size_t claims_count, const char* key, const size_t key_length)
 {
     if (claims == NULL || key == NULL || claims_count == 0 || key_length == 0)
         return NULL;
 
-    for (struct l8w8jwt_claim* claim = claims; claim < claims + claims_count; ++claim)
+    for (const struct l8w8jwt_claim* claim = claims; claim < claims + claims_count; ++claim)
     {
         if (strncmp(claim->key, key, key_length) == 0)
             return claim;

--- a/src/decode.c
+++ b/src/decode.c
@@ -168,8 +168,8 @@ static int l8w8jwt_decode_segments(const struct l8w8jwt_decoding_params* params,
 
     const int alg = params->alg;
 
-    char* current = params->jwt;
-    char* next = strchr(params->jwt, '.');
+    const char* current = params->jwt;
+    const char* next = strchr(params->jwt, '.');
 
     if (next == NULL) /* No payload. */
     {
@@ -376,7 +376,7 @@ static void l8w8jwt_validate_claims(const struct l8w8jwt_decoding_params* params
 
     if (params->validate_sub != NULL)
     {
-        struct l8w8jwt_claim* c = l8w8jwt_get_claim(claims->array, claims->length, "sub", 3);
+        const struct l8w8jwt_claim* c = l8w8jwt_get_claim(claims->array, claims->length, "sub", 3);
 
         validation_length = params->validate_sub_length ? params->validate_sub_length : strlen(params->validate_sub);
 
@@ -388,7 +388,7 @@ static void l8w8jwt_validate_claims(const struct l8w8jwt_decoding_params* params
 
     if (params->validate_aud != NULL)
     {
-        struct l8w8jwt_claim* c = l8w8jwt_get_claim(claims->array, claims->length, "aud", 3);
+        const struct l8w8jwt_claim* c = l8w8jwt_get_claim(claims->array, claims->length, "aud", 3);
 
         validation_length = params->validate_aud_length ? params->validate_aud_length : strlen(params->validate_aud);
 
@@ -400,7 +400,7 @@ static void l8w8jwt_validate_claims(const struct l8w8jwt_decoding_params* params
 
     if (params->validate_iss != NULL)
     {
-        struct l8w8jwt_claim* c = l8w8jwt_get_claim(claims->array, claims->length, "iss", 3);
+        const struct l8w8jwt_claim* c = l8w8jwt_get_claim(claims->array, claims->length, "iss", 3);
 
         validation_length = params->validate_iss_length ? params->validate_iss_length : strlen(params->validate_iss);
 
@@ -412,7 +412,7 @@ static void l8w8jwt_validate_claims(const struct l8w8jwt_decoding_params* params
 
     if (params->validate_jti != NULL)
     {
-        struct l8w8jwt_claim* c = l8w8jwt_get_claim(claims->array, claims->length, "jti", 3);
+        const struct l8w8jwt_claim* c = l8w8jwt_get_claim(claims->array, claims->length, "jti", 3);
 
         validation_length = params->validate_jti_length ? params->validate_jti_length : strlen(params->validate_jti);
 
@@ -426,7 +426,7 @@ static void l8w8jwt_validate_claims(const struct l8w8jwt_decoding_params* params
 
     if (params->validate_exp)
     {
-        struct l8w8jwt_claim* c = l8w8jwt_get_claim(claims->array, claims->length, "exp", 3);
+        const struct l8w8jwt_claim* c = l8w8jwt_get_claim(claims->array, claims->length, "exp", 3);
         if (c == NULL || ct - params->exp_tolerance_seconds > strtoll(c->value, NULL, 10))
         {
             *out_validation_result |= (unsigned)L8W8JWT_EXP_FAILURE;
@@ -435,7 +435,7 @@ static void l8w8jwt_validate_claims(const struct l8w8jwt_decoding_params* params
 
     if (params->validate_nbf)
     {
-        struct l8w8jwt_claim* c = l8w8jwt_get_claim(claims->array, claims->length, "nbf", 3);
+        const struct l8w8jwt_claim* c = l8w8jwt_get_claim(claims->array, claims->length, "nbf", 3);
         if (c == NULL || ct + params->nbf_tolerance_seconds < strtoll(c->value, NULL, 10))
         {
             *out_validation_result |= (unsigned)L8W8JWT_NBF_FAILURE;
@@ -444,7 +444,7 @@ static void l8w8jwt_validate_claims(const struct l8w8jwt_decoding_params* params
 
     if (params->validate_iat)
     {
-        struct l8w8jwt_claim* c = l8w8jwt_get_claim(claims->array, claims->length, "iat", 3);
+        const struct l8w8jwt_claim* c = l8w8jwt_get_claim(claims->array, claims->length, "iat", 3);
         if (c == NULL || ct + params->iat_tolerance_seconds < strtoll(c->value, NULL, 10))
         {
             *out_validation_result |= (unsigned)L8W8JWT_IAT_FAILURE;
@@ -453,7 +453,7 @@ static void l8w8jwt_validate_claims(const struct l8w8jwt_decoding_params* params
 
     if (params->validate_typ)
     {
-        struct l8w8jwt_claim* c = l8w8jwt_get_claim(claims->array, claims->length, "typ", 3);
+        const struct l8w8jwt_claim* c = l8w8jwt_get_claim(claims->array, claims->length, "typ", 3);
         if (c == NULL || l8w8jwt_strncmpic(c->value, params->validate_typ, params->validate_typ_length) != 0)
         {
             *out_validation_result |= (unsigned)L8W8JWT_TYP_FAILURE;
@@ -746,7 +746,7 @@ void l8w8jwt_decoding_params_init(struct l8w8jwt_decoding_params* params)
     params->alg = -2;
 }
 
-int l8w8jwt_validate_decoding_params(struct l8w8jwt_decoding_params* params)
+int l8w8jwt_validate_decoding_params(const struct l8w8jwt_decoding_params* params)
 {
     if (params == NULL || params->jwt == NULL || params->verification_key == NULL)
     {
@@ -768,7 +768,7 @@ int l8w8jwt_validate_decoding_params(struct l8w8jwt_decoding_params* params)
     return L8W8JWT_SUCCESS;
 }
 
-int l8w8jwt_decode(struct l8w8jwt_decoding_params* params, enum l8w8jwt_validation_result* out_validation_result, struct l8w8jwt_claim** out_claims, size_t* out_claims_length)
+int l8w8jwt_decode(const struct l8w8jwt_decoding_params* params, enum l8w8jwt_validation_result* out_validation_result, struct l8w8jwt_claim** out_claims, size_t* out_claims_length)
 {
     if (params == NULL || (out_claims != NULL && out_claims_length == NULL))
     {
@@ -857,7 +857,7 @@ exit:
     return r;
 }
 
-int l8w8jwt_decode_raw(struct l8w8jwt_decoding_params* params, enum l8w8jwt_validation_result* out_validation_result, char** out_header, size_t* out_header_length, char** out_payload, size_t* out_payload_length, uint8_t** out_signature, size_t* out_signature_length)
+int l8w8jwt_decode_raw(const struct l8w8jwt_decoding_params* params, enum l8w8jwt_validation_result* out_validation_result, char** out_header, size_t* out_header_length, char** out_payload, size_t* out_payload_length, uint8_t** out_signature, size_t* out_signature_length)
 {
     if
     (
@@ -969,7 +969,7 @@ exit:
     return r;
 }
 
-int l8w8jwt_decode_raw_no_validation(struct l8w8jwt_decoding_params* params, char** out_header, size_t* out_header_length, char** out_payload, size_t* out_payload_length, uint8_t** out_signature, size_t* out_signature_length)
+int l8w8jwt_decode_raw_no_validation(const struct l8w8jwt_decoding_params* params, char** out_header, size_t* out_header_length, char** out_payload, size_t* out_payload_length, uint8_t** out_signature, size_t* out_signature_length)
 {
     if
         (

--- a/src/encode.c
+++ b/src/encode.c
@@ -179,10 +179,11 @@ static int write_header_and_payload(chillbuff* stringbuilder, struct l8w8jwt_enc
         { .key = *(iatnbfexp + 00) ? "iat" : NULL, .key_length = 3, .value = iatnbfexp + 00, .value_length = 0, .type = L8W8JWT_CLAIM_TYPE_INTEGER },
         { .key = *(iatnbfexp + 21) ? "nbf" : NULL, .key_length = 3, .value = iatnbfexp + 21, .value_length = 0, .type = L8W8JWT_CLAIM_TYPE_INTEGER },
         { .key = *(iatnbfexp + 42) ? "exp" : NULL, .key_length = 3, .value = iatnbfexp + 42, .value_length = 0, .type = L8W8JWT_CLAIM_TYPE_INTEGER },
-        { .key = params->sub ? "sub" : NULL, .key_length = 3, .value = params->sub, .value_length = params->sub_length, .type = L8W8JWT_CLAIM_TYPE_STRING },
-        { .key = params->iss ? "iss" : NULL, .key_length = 3, .value = params->iss, .value_length = params->iss_length, .type = L8W8JWT_CLAIM_TYPE_STRING },
-        { .key = params->aud ? "aud" : NULL, .key_length = 3, .value = params->aud, .value_length = params->aud_length, .type = L8W8JWT_CLAIM_TYPE_STRING },
-        { .key = params->jti ? "jti" : NULL, .key_length = 3, .value = params->jti, .value_length = params->jti_length, .type = L8W8JWT_CLAIM_TYPE_STRING },
+        // Here we do an explicit cast that remove the const has we know further step will not touch the data
+        { .key = params->sub ? "sub" : NULL, .key_length = 3, .value = (char*)params->sub, .value_length = params->sub_length, .type = L8W8JWT_CLAIM_TYPE_STRING },
+        { .key = params->iss ? "iss" : NULL, .key_length = 3, .value = (char*)params->iss, .value_length = params->iss_length, .type = L8W8JWT_CLAIM_TYPE_STRING },
+        { .key = params->aud ? "aud" : NULL, .key_length = 3, .value = (char*)params->aud, .value_length = params->aud_length, .type = L8W8JWT_CLAIM_TYPE_STRING },
+        { .key = params->jti ? "jti" : NULL, .key_length = 3, .value = (char*)params->jti, .value_length = params->jti_length, .type = L8W8JWT_CLAIM_TYPE_STRING },
     };
 
     chillbuff_push_back(&buff, "{", 1);
@@ -612,7 +613,7 @@ void l8w8jwt_encoding_params_init(struct l8w8jwt_encoding_params* params)
     params->alg = -2;
 }
 
-int l8w8jwt_validate_encoding_params(struct l8w8jwt_encoding_params* params)
+int l8w8jwt_validate_encoding_params(const struct l8w8jwt_encoding_params* params)
 {
     if (params == NULL || params->secret_key == NULL || params->out == NULL || params->out_length == NULL)
     {

--- a/tests/tests.c
+++ b/tests/tests.c
@@ -2875,7 +2875,7 @@ static void test_l8w8jwt_decode_fwd_slashes_token_decode()
     enum l8w8jwt_validation_result validation_result;
     r = l8w8jwt_decode(&decoding_params, &validation_result, &ref, &claims_count);
 
-    struct l8w8jwt_claim* iss_claim = l8w8jwt_get_claim(ref, claims_count, "iss", 3);
+    const struct l8w8jwt_claim* iss_claim = l8w8jwt_get_claim(ref, claims_count, "iss", 3);
     TEST_ASSERT(strcmp(iss_claim->value, "https://test/domain/") == 0);
 }
 
@@ -3015,7 +3015,7 @@ static void test_l8w8jwt_get_claim()
     TEST_ASSERT(NULL == l8w8jwt_get_claim(NULL, 5, "alive", 5));
     TEST_ASSERT(NULL == l8w8jwt_get_claim(claims, 0, "alive", 5));
     TEST_ASSERT(NULL == l8w8jwt_get_claim(claims, 5, "test", 4));
-    struct l8w8jwt_claim* claim = l8w8jwt_get_claim(claims, sizeof(claims) / sizeof(struct l8w8jwt_claim), "alive", 5);
+    const struct l8w8jwt_claim* claim = l8w8jwt_get_claim(claims, sizeof(claims) / sizeof(struct l8w8jwt_claim), "alive", 5);
     TEST_ASSERT(strcmp(claim->key, "alive") == 0);
     TEST_ASSERT(strcmp(claim->value, "true") == 0);
 }


### PR DESCRIPTION
I'm usually a C++ developer and I add issues with some members of the `l8w8jwt_encoding_params` and `l8w8jwt_decoding_params` struct as all of them are not marked as `const`.

This had the problem of forcing the usage of a `const_cast` where technically it is not necessary. For example:
```cpp
void foo(std::string_view jwt)
{
    l8w8jwt_decoding_params params;
    l8w8jwt_decoding_params_init(&params);

    params.jwt = const_cast<char *>(jwt.c_str());
    params.jwt_length = jwt.size();
    // ...
    l8w8jwt_decode(&params, nullptr, nullptr, nullptr);
}
```

This PR is intended to solve this problem without actually breaking anything that was already present before.

Feel free to tell me if something is wrong or if some changes should be made.